### PR TITLE
fix: readme github command typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ git submodule add https://github.com/Myriad-Dreamin/typ.git
 You could fork and modify this repository, and then add it as a submodule in your own Typst project:
 
 ```bash
-git submodule add https://github.com/YOUR-NAME/typ.git -b YOUR-BRANCH-NAME
+git submodule add -b YOUR-BRANCH-NAME https://github.com/YOUR-NAME/typ.git 
 ```
 
 This gives opportunity to merge efforts together in future.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ git submodule add https://github.com/Myriad-Dreamin/typ.git
 You could fork and modify this repository, and then add it as a submodule in your own Typst project:
 
 ```bash
-git submodule add -b YOUR-BRANCH-NAME https://github.com/YOUR-NAME/typ.git 
+git rm --cached typ && rm -rf ./typ
+git submodule add -b YOUR-BRANCH-NAME https://github.com/YOUR-NAME/typ.git
 ```
 
 This gives opportunity to merge efforts together in future.

--- a/packages/zebraw.typ
+++ b/packages/zebraw.typ
@@ -1,4 +1,5 @@
 
-#import "@preview/zebraw:0.5.2": zebraw-init, zebraw
+// #import "@preview/zebraw:0.5.2": zebraw-init, zebraw
 
-// #import "zebraw/src/lib.typ": zebraw-init, zebraw
+// This is needed for inline raw support.
+#import "zebraw/src/lib.typ": zebraw-init, zebraw

--- a/packages/zebraw.typ
+++ b/packages/zebraw.typ
@@ -1,4 +1,4 @@
 
-// #import "@preview/zebraw:0.5.2": zebraw-init, zebraw
+#import "@preview/zebraw:0.5.2": zebraw-init, zebraw
 
-#import "zebraw/src/lib.typ": zebraw-init, zebraw
+// #import "zebraw/src/lib.typ": zebraw-init, zebraw


### PR DESCRIPTION
the `-b YOUR-BRANCH-NAME` parameter should be placed before the repository url. 

BTW, one should actually delete the `./typ` directory before running this command, should this be mentioned?