### PR TITLE
fix: render comment math as MathML

### DIFF
--- a/templates/comment.typ
+++ b/templates/comment.typ
@@ -1,17 +1,17 @@
 #import "@preview/cmarker:0.1.5"
 #import "@preview/mitex:0.2.5": mitex
-#import "blog.typ": markup-rules, equation-rules, code-block-rules, plain-text
+#import "blog.typ": markup-rules, mathyml-equation-rules, code-block-rules, plain-text
 // markup setting
 #show: markup-rules
 // math setting
-#show: equation-rules
+#show: mathyml-equation-rules
 // code block setting
 #show: code-block-rules
 #show raw.where(lang: "md-render"): it => cmarker.render(
   raw-typst: false,
   it.text,
   h1-level: 2,
-  // math: mitex,
+  math: mitex,
   html: (
     userref: (attrs, body) => html.elem(
       "a",


### PR DESCRIPTION
This pull request updates the way equations are handled in the `comment.typ` template by switching from the old equation rules to new `mathyml-equation-rules`. It also re-enables the use of the `mitex` math renderer for Markdown rendering. These changes ensure better compatibility and improved math rendering in comments.

* Switched from `equation-rules` to `mathyml-equation-rules` for displaying equations, likely to support a more modern or feature-rich equation rendering approach.
* Re-enabled the `mitex` math renderer in the Markdown rendering pipeline by uncommenting its usage, ensuring that math expressions are properly rendered in Markdown blocks.