### PR TITLE
feat: use native Typst MathML export and correct html detection

### DIFF
--- a/packages/mathyml.typ
+++ b/packages/mathyml.typ
@@ -1,2 +1,0 @@
-// https://codeberg.org/akida/mathyml
-#import "mathyml/src/lib.typ": *

--- a/templates/comment.typ
+++ b/templates/comment.typ
@@ -1,10 +1,10 @@
 #import "@preview/cmarker:0.1.5"
-#import "@preview/mitex:0.2.5": mitex
-#import "blog.typ": markup-rules, mathyml-equation-rules, code-block-rules, plain-text
+#import "@preview/mitex:0.2.7": mitex
+#import "blog.typ": markup-rules, equation-rules, code-block-rules, plain-text
 // markup setting
 #show: markup-rules
 // math setting
-#show: mathyml-equation-rules
+#show: equation-rules
 // code block setting
 #show: code-block-rules
 #show raw.where(lang: "md-render"): it => cmarker.render(

--- a/templates/comment.typ
+++ b/templates/comment.typ
@@ -1,17 +1,17 @@
 #import "@preview/cmarker:0.1.5"
 #import "@preview/mitex:0.2.5": mitex
-#import "blog.typ": markup-rules, equation-rules, code-block-rules, plain-text
+#import "blog.typ": markup-rules, mathyml-equation-rules, code-block-rules, plain-text
 // markup setting
 #show: markup-rules
 // math setting
-#show: equation-rules
+#show: mathyml-equation-rules
 // code block setting
 #show: code-block-rules
 #show raw.where(lang: "md-render"): it => cmarker.render(
   raw-typst: false,
   it.text,
   h1-level: 2,
-  // math: mitex,
+  math: mitex,
   html: (
     userref: (attrs, body) => html.elem(
       "a",

--- a/templates/shared.typ
+++ b/templates/shared.typ
@@ -16,6 +16,7 @@
 // #let default-kind = "monthly"
 
 #let build-kind = sys.inputs.at("build-kind", default: default-kind)
+#let math-render = sys.inputs.at("math-render", default: "mathml")
 
 #let text-fonts = (
   "Libertinus Serif",
@@ -78,6 +79,41 @@
 
 #let equation-rules(body) = {
   show math.equation: set text(weight: 400)
+  body
+}
+
+#let svg-equation-rules(body) = {
+  show math.equation: set text(weight: 400)
+  show math.equation.where(block: true): it => context if shiroa-sys-target() == "html" {
+    theme-frame(
+      tag: "div",
+      theme => {
+        set text(fill: theme.main-color)
+        html.elem(
+          "p",
+          html.frame(it),
+          attrs: ("class": "block-equation", "role": "math"),
+        )
+      },
+    )
+  } else {
+    it
+  }
+  show math.equation.where(block: false): it => context if shiroa-sys-target() == "html" {
+    theme-frame(
+      tag: "span",
+      theme => {
+        set text(fill: theme.main-color)
+        html.elem(
+          "span",
+          html.frame(it),
+          attrs: (class: "inline-equation"),
+        )
+      },
+    )
+  } else {
+    it
+  }
   body
 }
 
@@ -239,7 +275,7 @@
       region: region,
     )
     // math setting
-    show: equation-rules
+    show: if math-render == "svg" { svg-equation-rules } else { equation-rules }
     // code block setting
     show: code-block-rules
     // visualization setting

--- a/templates/shared.typ
+++ b/templates/shared.typ
@@ -5,20 +5,12 @@
 #import "mod.typ": *
 #import "theme.typ": *
 
-// Settings
-// todo: load from env or config?
-#let use-mathyml = true
-
-#import "../packages/mathyml.typ": prelude
-#import "empty.typ" as _empty
-#import if use-mathyml { prelude } else { _empty }: *
-
 // Metadata
 #let is-html-target = is-html-target()
 #let is-pdf-target = is-pdf-target()
 #let is-web-target = is-web-target() or sys-is-html-target
 #let is-md-target = target == "md"
-#let sys-is-html-target = ("target" in dictionary(std))
+#let sys-is-html-target = ("html" in dictionary(std))
 
 #let default-kind = "post"
 // #let default-kind = "monthly"
@@ -44,11 +36,6 @@
 // ,
 #let heading-sizes = (22pt, 18pt, 14pt, 12pt, main-size)
 #let list-indent = 0.5em
-
-/// Creates an embedded block typst frame.
-#let div-frame(content, attrs: (:), tag: "div") = html.elem(tag, html.frame(content), attrs: attrs)
-#let span-frame = div-frame.with(tag: "span")
-#let p-frame = div-frame.with(tag: "p")
 
 // defaults
 #let (
@@ -91,41 +78,6 @@
 
 #let equation-rules(body) = {
   show math.equation: set text(weight: 400)
-  show math.equation.where(block: true): it => context if shiroa-sys-target() == "html" {
-    theme-frame(
-      tag: "div",
-      theme => {
-        set text(fill: theme.main-color)
-        p-frame(attrs: ("class": "block-equation", "role": "math"), it)
-      },
-    )
-  } else {
-    it
-  }
-  show math.equation.where(block: false): it => context if shiroa-sys-target() == "html" {
-    theme-frame(
-      tag: "span",
-      theme => {
-        set text(fill: theme.main-color)
-        span-frame(attrs: (class: "inline-equation"), it)
-      },
-    )
-  } else {
-    it
-  }
-  body
-}
-
-// https://codeberg.org/akida/mathyml
-#let mathyml-equation-rules(body) = {
-  import "../packages/mathyml.typ": try-to-mathml
-
-  // math rules
-  show math.equation: set text(weight: 500)
-  // show math.equation: to-mathml
-  show math.equation: try-to-mathml
-
-
   body
 }
 
@@ -287,7 +239,7 @@
       region: region,
     )
     // math setting
-    show: if use-mathyml { mathyml-equation-rules } else { equation-rules }
+    show: equation-rules
     // code block setting
     show: code-block-rules
     // visualization setting

--- a/templates/shared.typ
+++ b/templates/shared.typ
@@ -38,6 +38,11 @@
 #let heading-sizes = (22pt, 18pt, 14pt, 12pt, main-size)
 #let list-indent = 0.5em
 
+/// Creates an embedded block typst frame.
+#let div-frame(content, attrs: (:), tag: "div") = html.elem(tag, html.frame(content), attrs: attrs)
+#let span-frame = div-frame.with(tag: "span")
+#let p-frame = div-frame.with(tag: "p")
+
 // defaults
 #let (
   style: theme-style,
@@ -89,11 +94,7 @@
       tag: "div",
       theme => {
         set text(fill: theme.main-color)
-        html.elem(
-          "p",
-          html.frame(it),
-          attrs: ("class": "block-equation", "role": "math"),
-        )
+        p-frame(attrs: ("class": "block-equation", "role": "math"), it)
       },
     )
   } else {
@@ -104,11 +105,7 @@
       tag: "span",
       theme => {
         set text(fill: theme.main-color)
-        html.elem(
-          "span",
-          html.frame(it),
-          attrs: (class: "inline-equation"),
-        )
+        span-frame(attrs: (class: "inline-equation"), it)
       },
     )
   } else {

--- a/templates/target.typ
+++ b/templates/target.typ
@@ -1,2 +1,2 @@
 
-#let sys-is-html-target = ("target" in dictionary(std))
+#let sys-is-html-target = ("html" in dictionary(std))

--- a/templates/theme.typ
+++ b/templates/theme.typ
@@ -1,8 +1,8 @@
 #import "@preview/shiroa:0.2.3": templates, book-sys
 #import templates: *
+#import "target.typ": sys-is-html-target
 
 #let is-md-target = book-sys.target == "md"
-#let sys-is-html-target = book-sys.sys-is-html-target
 
 // Theme (Colors)
 #let dark-theme = book-theme-from(toml("theme-style.toml"), xml: it => xml(it), target: "web-ayu")


### PR DESCRIPTION
- remove the vendored mathyml package and switch the default equation path to Typst's native MathML HTML export
- keep the SVG/html.frame equation path available via `math-render: "svg"`
- preserve `.inline-equation` and `.block-equation` wrappers for the SVG fallback
- update comment rendering to use `equation-rules` with mitex 0.2.7
- use the presence of `std.html` for HTML target detection under Typst 0.15
